### PR TITLE
Remove doubled title on contribute page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,6 @@ title: Kontribusi di Belajarpython
 permalink: /contribute/
 ---
 
-# Kontribusi di Belajarpython
-
 Sebelumnya, terimakasih banyak karena telah meluangkan waktu Anda untuk ikut berkontribusi!
 
 Belajarpython adalah situs terbuka (open source) yang dikembangkan oleh developer untuk developer. Semua orang baik dari kalangan :trollface: developer, :man: mahasiswa, :older_woman: pengajar, bahkan :baby: anak kecil yang baru mempelajari bahasa pemrograman python bisa ikut memberikan :heart: kontribusinya di sini.


### PR DESCRIPTION
The title has been defined along with `layout` and `permalink` so it is not needed to write the Title as #. 

Ref: https://github.com/belajarpythoncom/belajarpython.com/issues/39