### PR TITLE
Add hover states to navigation links

### DIFF
--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -1,9 +1,16 @@
 <footer class="bg-slate-300 py-4">
     <div class="flex justify-center">
         <div class="flex gap-4 text-sm font-bold uppercase text-slate-600 md:gap-6">
-            <a href="{{ '/en/' if lang == 'en' else '/' }}">Home</a>
-            <a href="/about">About</a>
-            <a target="_blank" href="https://goo.gl/forms/ZPyZgIagXcanYwzH2">Contact</a>
+            <a
+                class="cursor-pointer transition duration-200 hover:text-primary-500 hover:underline focus:outline-none focus:ring-4 focus:ring-blue-500"
+                href="{{ '/en/' if lang == 'en' else '/' }}">Home</a>
+            <a
+                class="cursor-pointer transition duration-200 hover:text-primary-500 hover:underline focus:outline-none focus:ring-4 focus:ring-blue-500"
+                href="/about">About</a>
+            <a
+                class="cursor-pointer transition duration-200 hover:text-primary-500 hover:underline focus:outline-none focus:ring-4 focus:ring-blue-500"
+                target="_blank"
+                href="https://goo.gl/forms/ZPyZgIagXcanYwzH2">Contact</a>
         </div>
     </div>
 </footer>

--- a/src/_includes/navbar.njk
+++ b/src/_includes/navbar.njk
@@ -20,7 +20,7 @@
                 <a class="text-white text-opacity-70 hover:text-opacity-100" href="{{ '/en/contribute' if lang == 'en' else '/contribute' }}">{{ 'Contribute' if lang == 'en' else 'Kontribusi' }}</a>
             </div>
             <a
-                class="flex h-9 items-center rounded-full bg-gradient-to-l from-secondary-500 to-secondary-400 px-7 text-sm text-black"
+                class="flex h-9 cursor-pointer items-center rounded-full bg-gradient-to-l from-secondary-500 to-secondary-400 px-7 text-sm text-black transition duration-200 ease-out hover:scale-105 hover:opacity-80 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-blue-500"
                 href="https://github.com/belajarpythoncom/belajarpython.com">
                 <span class="-mt-0.5">Join on Github</span>
                 <img class="ml-2 h-4" src="/img/icon-github.svg" class="button-github-yellow-img"/>


### PR DESCRIPTION
## Summary
- add hover, cursor, and focus states to footer navigation links
- add hover scale/color feedback and focus ring to the "Join on Github" header button

Fixes #107

## Verification
- npm ci
- npm run build
- git diff --check
